### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/bloodbank/build.gradle
+++ b/bloodbank/build.gradle
@@ -170,7 +170,7 @@ dependencies {
 		'commons/commons-fileupload-1.2.jar',
 		'commons/commons-codec-1.9.jar',
 		'commons/commons-httpclient-3.1.jar',
-		'commons/commons-collections-3.2.1.jar',
+		'commons/commons-collections-3.2.2.jar',
 		'commons/asm-commons-4.1.jar',
 		'eclipse/eclipselink-2.5.1.jar',
 		'eclipse/javax.persistence-2.0.0.jar',

--- a/bloodbank/pom.xml
+++ b/bloodbank/pom.xml
@@ -441,7 +441,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>

--- a/bloodbankScheduler/build.gradle
+++ b/bloodbankScheduler/build.gradle
@@ -95,7 +95,7 @@ dependencies {
 		'commons/commons-fileupload-1.2.jar',
 		'commons/commons-codec-1.9.jar',
 		'commons/commons-httpclient-3.1.jar',
-		'commons/commons-collections-3.2.1.jar',
+		'commons/commons-collections-3.2.2.jar',
 		'commons/asm-commons-4.1.jar',
 		'eclipse/eclipselink-2.5.1.jar',
 		'eclipse/javax.persistence-2.0.0.jar',

--- a/bloodbankScheduler/pom.xml
+++ b/bloodbankScheduler/pom.xml
@@ -462,7 +462,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>

--- a/surveyportal/build.gradle
+++ b/surveyportal/build.gradle
@@ -170,7 +170,7 @@ dependencies {
 		'commons/commons-fileupload-1.2.jar',
 		'commons/commons-codec-1.9.jar',
 		'commons/commons-httpclient-3.1.jar',
-		'commons/commons-collections-3.2.1.jar',
+		'commons/commons-collections-3.2.2.jar',
 		'commons/asm-commons-4.1.jar',
 		'eclipse/eclipselink-2.5.1.jar',
 		'eclipse/javax.persistence-2.0.0.jar',

--- a/surveyportal/pom.xml
+++ b/surveyportal/pom.xml
@@ -441,7 +441,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>

--- a/surveyportalScheduler/build.gradle
+++ b/surveyportalScheduler/build.gradle
@@ -95,7 +95,7 @@ dependencies {
 		'commons/commons-fileupload-1.2.jar',
 		'commons/commons-codec-1.9.jar',
 		'commons/commons-httpclient-3.1.jar',
-		'commons/commons-collections-3.2.1.jar',
+		'commons/commons-collections-3.2.2.jar',
 		'commons/asm-commons-4.1.jar',
 		'eclipse/eclipselink-2.5.1.jar',
 		'eclipse/javax.persistence-2.0.0.jar',

--- a/surveyportalScheduler/pom.xml
+++ b/surveyportalScheduler/pom.xml
@@ -462,7 +462,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>

--- a/testprok/build.gradle
+++ b/testprok/build.gradle
@@ -170,7 +170,7 @@ dependencies {
 		'commons/commons-fileupload-1.2.jar',
 		'commons/commons-codec-1.9.jar',
 		'commons/commons-httpclient-3.1.jar',
-		'commons/commons-collections-3.2.1.jar',
+		'commons/commons-collections-3.2.2.jar',
 		'commons/asm-commons-4.1.jar',
 		'eclipse/eclipselink-2.5.1.jar',
 		'eclipse/javax.persistence-2.0.0.jar',

--- a/testprok/pom.xml
+++ b/testprok/pom.xml
@@ -441,7 +441,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>

--- a/testprokScheduler/build.gradle
+++ b/testprokScheduler/build.gradle
@@ -95,7 +95,7 @@ dependencies {
 		'commons/commons-fileupload-1.2.jar',
 		'commons/commons-codec-1.9.jar',
 		'commons/commons-httpclient-3.1.jar',
-		'commons/commons-collections-3.2.1.jar',
+		'commons/commons-collections-3.2.2.jar',
 		'commons/asm-commons-4.1.jar',
 		'eclipse/eclipselink-2.5.1.jar',
 		'eclipse/javax.persistence-2.0.0.jar',

--- a/testprokScheduler/pom.xml
+++ b/testprokScheduler/pom.xml
@@ -462,7 +462,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
